### PR TITLE
fixed console stacktrace if you use ctrl-c to quit search results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# yarn
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -79,6 +79,9 @@ program
 			printer.printSearchResults(resultType, results);
 			prompt.start();
 			prompt.get(['selection'], function (err, result) {
+				if (err) {
+					return process.stdout.write('\n');
+				}
 				if(results[result.selection-1]){
 					var selectedSpotifyURI = results[result.selection-1].spotifyURI;
 					spotifyClient.play(selectedSpotifyURI).then(() => {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "lodash": "^4.17.4",
-    "lyricist-dev": "https://github.com/ersel/lyricist.git",
+    "lyricist": "https://github.com/ersel/lyricist.git",
     "moment": "^2.17.1",
     "moment-duration-format": "^1.3.0",
     "nconf": "^0.8.4",


### PR DESCRIPTION
Replication steps:

* `spotify search <term>`
* `ctrl-c` to cancel/exit

Plus some yarn-friendly changes